### PR TITLE
Ticket1378 Linux Fixes

### DIFF
--- a/configure/RULES.ioc.ISIS
+++ b/configure/RULES.ioc.ISIS
@@ -42,7 +42,7 @@ ifneq ($(findstring linux,$(EPICS_HOST_ARCH)),)
 	@echo 'IOCDIRNAME=`basename $$MYDIR`'>> $@
 	@echo 'IOCEXE=`echo $$IOCDIRNAME | sed -e "s/^ioc//"`'>>$@
 	@echo 'OLDPATH=$$PATH'>> $@
-	@echo '. $(EPICS_ROOT)/config_env_base.sh'>> $@
+	@echo '. $(EPICS_ROOT)/config_env_base.sh ""'>> $@
 	@echo '$${MYDIR}/../../bin/$(ARCH)/$${IOCEXE} $$*'>> $@
 	@echo 'export PATH=$$OLDPATH'>> $@
 	@echo 'export EPICS_CAS_INTF_ADDR_LIST="$$OLDEPICS_CAS_INTF_ADDR_LIST"'>> $@


### PR DESCRIPTION
Closes https://github.com/ISISComputingGroup/IBEX/issues/1378.

`st.cmd` was being stored in `build_arch.txt` because of a peculiarity of shell script behaviour in Linux.

When a script is `source`d (rather than executed) without arguments, the arguments of the parent script are passed through (since sourcing effectively represents pulling the contents into the current context).

`config_env_base.sh` was being sourced without arguments and causing the `st.cmd` argument from the parent script (various generated `runIOC.sh` scripts) to be passed through, again, when it in turn sourced `config_env.sh` without arguments.

Previously this wasn't an issue because `config_env_base.sh` was sourcing `config_env.sh` with arguments, but this changed in https://github.com/ISISComputingGroup/EPICS/commit/8bc6d791c8f3128d59558d3e7c981dbfaf78a511.

Fixed by passed an empty argument when sourcing `config_env_base.sh` from `runIOC.sh` scripts.