### PR TITLE
Assume st.cmd if no arg given

### DIFF
--- a/configure/RULES.ioc.ISIS
+++ b/configure/RULES.ioc.ISIS
@@ -25,7 +25,12 @@ ifeq ($(findstring cygwin,$(EPICS_HOST_ARCH)),)
 	@echo call %%MYDIR%%dllPath.bat>> $@
 	@echo call $(subst /,\,$(EPICS_ROOT))\utils_win32\master\bin\shorten_path.bat PATH>> $@
 	@echo set "PATH=%%PATH%%;%%PREPATH%%">> $@
-	@echo %%MYDIR%%..\..\bin\$(ARCH)\%%IOCEXE%% %%*>> $@
+	@echo if "%%1" == "" (>> $@
+	@echo    set "CMDST=st.cmd">> $@
+	@echo ) else (>> $@
+	@echo    set "CMDST=%%1">> $@
+	@echo )>> $@
+	@echo %%MYDIR%%..\..\bin\$(ARCH)\%%IOCEXE%% %%CMDST%%>> $@
 	@echo set "PATH=%%OLDPATH%%">> $@
 	@echo set EPICS_CAS_INTF_ADDR_LIST=%%OLDEPICS_CAS_INTF_ADDR_LIST%%>> $@
 	@echo set EPICS_CAS_BEACON_ADDR_LIST=%%OLDEPICS_CAS_BEACON_ADDR_LIST%%>> $@


### PR DESCRIPTION
To test:

you need to make clean uninstall and then remake to get runIOC.bat regenerated, then check all works as expected. 

To start an ioc from the command line with running st,cmd use e.g.

runIOC.bat NUL

 