### PR TITLE
Make sure use long paths internally

### DIFF
--- a/src/tools/EPICS/Path.pm
+++ b/src/tools/EPICS/Path.pm
@@ -52,8 +52,8 @@ sub UnixPath {
         $newpath =~ s{\\}{/}go;
         $newpath =~ s{^([a-zA-Z]):/}{/cygdrive/$1/};
     } elsif ($^O eq 'MSWin32') {
-	    use Win32;
-		$newpath = Win32::GetLongPathName($newpath);
+        use if $^O eq 'MSWin32', 'Win32';
+        $newpath = Win32::GetLongPathName($newpath);
         $newpath =~ s{\\}{/}go;
     }
     return $newpath;

--- a/src/tools/EPICS/Path.pm
+++ b/src/tools/EPICS/Path.pm
@@ -52,6 +52,8 @@ sub UnixPath {
         $newpath =~ s{\\}{/}go;
         $newpath =~ s{^([a-zA-Z]):/}{/cygdrive/$1/};
     } elsif ($^O eq 'MSWin32') {
+	    use Win32;
+		$newpath = Win32::GetLongPathName($newpath);
         $newpath =~ s{\\}{/}go;
     }
     return $newpath;


### PR DESCRIPTION
This fixes a specific issue with makeBaseApp.pl when short
paths have been used in PATH - the $0 variable contains the
short path to EPICS_BASE and then this gets used to create
the ioc

See ISISComputingGroup/IBEX#1508

To test - you need to be in a directory without an existing configure/RELEASE file: 
mkdir ioc/something_new
cd ioc/something_new
makebaseapp.pl -t ioc testioc
check base path in configure/RELEASE is OK
