### PR TITLE
Ticket2831: Added code to log any severity

### DIFF
--- a/src/libCom/iocsh/libComRegister.c
+++ b/src/libCom/iocsh/libComRegister.c
@@ -206,14 +206,14 @@ static void errlogCallFunc(const iocshArgBuf *args)
 }
 
 /* errlogSev */
-static const iocshArg errlogSevArg0 = { "message",iocshArgString};
-static const iocshArg errlogSevArg1 = { "severity",iocshArgInt};
+static const iocshArg errlogSevArg0 = { "severity",iocshArgInt};
+static const iocshArg errlogSevArg1 = { "message",iocshArgString};
 static const iocshArg * const errlogSevArgs[] = 
     {&errlogSevArg0, &errlogSevArg1};
 static const iocshFuncDef errlogSevFuncDef = {"errlogSev",2,errlogSevArgs};
 static void errlogSevCallFunc(const iocshArgBuf *args)
 {
-    errlogSevPrintf(args[1].ival, "%s\n", args[0].sval);
+    errlogSevPrintf(args[0].ival, "%s\n", args[1].sval);
 }
 
 /* iocLogPrefix */

--- a/src/libCom/iocsh/libComRegister.c
+++ b/src/libCom/iocsh/libComRegister.c
@@ -205,6 +205,17 @@ static void errlogCallFunc(const iocshArgBuf *args)
     errlogPrintfNoConsole("%s\n", args[0].sval);
 }
 
+/* errlogSev */
+static const iocshArg errlogSevArg0 = { "message",iocshArgString};
+static const iocshArg errlogSevArg1 = { "severity",iocshArgInt};
+static const iocshArg * const errlogSevArgs[] = 
+    {&errlogSevArg0, &errlogSevArg1};
+static const iocshFuncDef errlogSevFuncDef = {"errlogSev",2,errlogSevArgs};
+static void errlogSevCallFunc(const iocshArgBuf *args)
+{
+    errlogSevPrintf(args[1].ival, "%s\n", args[0].sval);
+}
+
 /* iocLogPrefix */
 static const iocshArg iocLogPrefixArg0 = { "prefix",iocshArgString};
 static const iocshArg * const iocLogPrefixArgs[1] = {&iocLogPrefixArg0};
@@ -379,6 +390,7 @@ void epicsShareAPI libComRegister(void)
     iocshRegister(&errlogInitFuncDef,errlogInitCallFunc);
     iocshRegister(&errlogInit2FuncDef,errlogInit2CallFunc);
     iocshRegister(&errlogFuncDef, errlogCallFunc);
+    iocshRegister(&errlogSevFuncDef, errlogSevCallFunc);
     iocshRegister(&iocLogPrefixFuncDef, iocLogPrefixCallFunc);
 
     iocshRegister(&epicsThreadShowAllFuncDef,epicsThreadShowAllCallFunc);


### PR DESCRIPTION
This PR adds a new logging method that can be called for https://github.com/ISISComputingGroup/IBEX/issues/2831