### PR TITLE
Ticket2991 changes to make iocs easier to share

### DIFF
--- a/src/template/base/top/iocApp/src/build.mak
+++ b/src/template/base/top/iocApp/src/build.mak
@@ -48,6 +48,7 @@ $(APPNAME)_LIBS += stream
 $(APPNAME)_LIBS += pcre
 $(APPNAME)_LIBS += asyn
 ## Add other libraries here ##
+$(APPNAME)_LIBS += calc
 #$(APPNAME)_LIBS += xxx
 
 # _APPNAME__registerRecordDeviceDriver.cpp derives from _APPNAME_.dbd

--- a/src/template/base/top/iocBoot/ioc/st.cmd@Common
+++ b/src/template/base/top/iocBoot/ioc/st.cmd@Common
@@ -32,6 +32,12 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "baud", "$(BAUD=960
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "bits", "$(BITS=8)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "parity", "$(PARITY=none)")
 $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)")
+## Hardware flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", 0, "clocal", "Y")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"crtscts","N")
+## Software flow control off
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixon","N")
+$(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)",0,"ixoff","N")
 
 ## Load record instances
 

--- a/src/template/base/top/iocBoot/ioc/st.cmd@Common
+++ b/src/template/base/top/iocBoot/ioc/st.cmd@Common
@@ -39,7 +39,7 @@ $(IFNOTDEVSIM) $(IFNOTRECSIM) asynSetOption("$(DEVICE)", -1, "stop", "$(STOP=1)"
 < $(IOCSTARTUP)/dbload.cmd
 
 ## Load our record instances
-dbLoadRecords("db/_DB_NAME_.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX)$(IOCNAME):,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE)")
+dbLoadRecords("$(_SUPPORT_MACRO_)/db/_NAME_LOWER_.db","PVPREFIX=$(MYPVPREFIX),P=$(MYPVPREFIX)$(IOCNAME):,RECSIM=$(RECSIM=0),DISABLE=$(DISABLE=0),PORT=$(DEVICE)")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd


### PR DESCRIPTION
Added calc library so IOC can be run.
Explicitly set flow control off.
dbLoadRecords now looks in the support module for the db file.

https://github.com/ISISComputingGroup/IBEX/issues/2991

Flow control changes covered in:
https://github.com/ISISComputingGroup/IBEX/issues/3180

Linked to: https://github.com/ISISComputingGroup/IBEX_device_generator/pull/6
https://github.com/ISISComputingGroup/EPICS-asyn/pull/13
