### PR TITLE
Close redirectered stdout

### DIFF
--- a/src/ioc/dbtemplate/msi.c
+++ b/src/ioc/dbtemplate/msi.c
@@ -159,6 +159,10 @@ int main(int argc,char **argv)
     if (opt_D) {
         printf("\n");
     }
+    if (outFile)
+    {
+        fclose(stdout);
+    }
     free(templateName);
     free(substitutionName);
     return opt_V & 2;


### PR DESCRIPTION
Close redirected stdout to avoid lost characters on Windows

See ISISComputingGroup/IBEX#4500
