### PR TITLE
Do not automatically generate dllCopy.bat

### DIFF
--- a/configure/RULES.ioc.ISIS
+++ b/configure/RULES.ioc.ISIS
@@ -2,7 +2,7 @@
 # may want to consider replacing $(ARCH) with %%EPICS_HOST_ARCH%% at some point,
 # but would need to adjust the generating of dllPath.bat too
 # note: runIOC.bat does not directly depend on dllCopy.bat but convenient to generate it this way
-runIOC.bat : dllPath.bat dllCopy.bat
+runIOC.bat : dllPath.bat
 ifneq ($(findstring win,$(EPICS_HOST_ARCH)),)
 ifeq ($(findstring cygwin,$(EPICS_HOST_ARCH)),)
 	@echo Generating runIOC.bat


### PR DESCRIPTION
It can be generated manually if needed by running "make dllCopy.bat" in the ioc directory