### PR TITLE
Add template files missed in v7 upgrade

### DIFF
--- a/modules/database/src/template/Makefile
+++ b/modules/database/src/template/Makefile
@@ -6,7 +6,9 @@ TEMPLATES_DIR = makeBaseApp
 
 TEMPLATES += top/iocApp/Makefile
 TEMPLATES += top/iocApp/Db/Makefile
+TEMPLATES += top/iocApp/protocol/Makefile
 TEMPLATES += top/iocApp/src/Makefile
+TEMPLATES += top/iocApp/src/build.mak
 TEMPLATES += top/iocApp/src/_APPNAME_Main.cpp
 
 TEMPLATES += top/exampleApp/Makefile
@@ -58,6 +60,7 @@ TEMPLATES += top/iocBoot/ioc/Makefile@win32
 TEMPLATES += top/iocBoot/ioc/Makefile@windows
 TEMPLATES += top/iocBoot/ioc/Makefile@cygwin
 TEMPLATES += top/iocBoot/ioc/st.cmd@Common
+TEMPLATES += top/iocBoot/ioc/st-common.cmd@Common
 TEMPLATES += top/iocBoot/ioc/st.cmd@Cross
 TEMPLATES += top/iocBoot/ioc/st.cmd@vxWorks
 TEMPLATES += top/iocBoot/ioc/st.cmd@RTEMS

--- a/src/template/base/Makefile
+++ b/src/template/base/Makefile
@@ -16,6 +16,7 @@ TEMPLATES += top/configure/RULES_TOP
 
 TEMPLATES += top/supportApp/Makefile
 TEMPLATES += top/supportApp/Db/Makefile
+TEMPLATES += top/supportApp/protocol/Makefile
 TEMPLATES += top/supportApp/src/Makefile
 TEMPLATES += top/supportApp/src/_APPNAME_.dbd
 


### PR DESCRIPTION
The directory structure changed location in v7, so though out local extra files are present in the source tree they are not all copied to the build tree and hence missed by makeBaseApp.pl when creating an IOC