### PR TITLE
Detect if Visual Studio 2019 is installed

### DIFF
--- a/startup/win32.bat
+++ b/startup/win32.bat
@@ -97,6 +97,10 @@ for %%i in ( Community Professional Enterprise ) do (
         set "VCVERSION=15.0"
         set "_vcvarsalldir=%_progfiles%\Microsoft Visual Studio\2017\%%i\VC\Auxiliary\Build"
     )
+    if exist "%_progfiles%\Microsoft Visual Studio\2019\%%i\VC\Auxiliary\Build" (
+        set "VCVERSION=16.0"
+        set "_vcvarsalldir=%_progfiles%\Microsoft Visual Studio\2019\%%i\VC\Auxiliary\Build"
+    )
 )
 if exist "%_vcvarsalldir%\vcvarsall.bat" (
     @echo Using Visual Studio %VCVERSION% x86 native compiler

--- a/startup/windows.bat
+++ b/startup/windows.bat
@@ -96,7 +96,11 @@ for %%i in ( Community Professional Enterprise ) do (
     if exist "%_progfiles%\Microsoft Visual Studio\2017\%%i\VC\Auxiliary\Build" (
         set "VCVERSION=15.0"
         set "_vcvarsalldir=%_progfiles%\Microsoft Visual Studio\2017\%%i\VC\Auxiliary\Build"
-	)
+    )
+    if exist "%_progfiles%\Microsoft Visual Studio\2019\%%i\VC\Auxiliary\Build" (
+        set "VCVERSION=16.0"
+        set "_vcvarsalldir=%_progfiles%\Microsoft Visual Studio\2019\%%i\VC\Auxiliary\Build"
+    )
 )
 REM -- express 2012 provides a 32->64 cross compiler, the full visual studio has both a cross and native compiler
 if exist "%_vcvarsalldir%\vcvars64.bat" (


### PR DESCRIPTION
Part of ISISComputingGroup/IBEX#5173

Sets the Visual Studio version to `16.0` if Visual Studio 2019 is installed.
