### PR TITLE
Move calcSupport.dbd to before asyn.dbd

### DIFF
--- a/modules/database/src/template/top/iocApp/src/build.mak
+++ b/modules/database/src/template/top/iocApp/src/build.mak
@@ -25,10 +25,10 @@ $(APPNAME)_DBD += devIocStats.dbd
 $(APPNAME)_DBD += caPutLog.dbd
 $(APPNAME)_DBD += utilities.dbd
 ## Stream device support ##
+$(APPNAME)_DBD += calcSupport.dbd
 $(APPNAME)_DBD += asyn.dbd
 $(APPNAME)_DBD += drvAsynSerialPort.dbd
 $(APPNAME)_DBD += drvAsynIPPort.dbd
-$(APPNAME)_DBD += calcSupport.dbd
 $(APPNAME)_DBD += luaSupport.dbd
 $(APPNAME)_DBD += stream.dbd
 ## add other dbd here ##


### PR DESCRIPTION
In the future, asyn can support sCalcout so need to include calcSupport before asyn