### PR TITLE
Use GetTickCount64 to avoid wrap at 49.7 days

### DIFF
--- a/modules/libcom/src/osi/os/WIN32/osdMonotonic.c
+++ b/modules/libcom/src/osi/os/WIN32/osdMonotonic.c
@@ -46,7 +46,7 @@ epicsUInt64 epicsMonotonicGet(void)
         } else
             return val.QuadPart;
     } else {
-        epicsUInt64 ret = GetTickCount();
+        epicsUInt64 ret = GetTickCount64();
         ret *= 1000000;
         return ret;
     }


### PR DESCRIPTION
Use GetTickCount64() which does not wrap after 49.7 days of uptime

See ISISComputingGroup/IBEX#5717
