### PR TITLE
Disable whole program optimisation by default

### DIFF
--- a/configure/os/CONFIG.win32-x86.win32-x86
+++ b/configure/os/CONFIG.win32-x86.win32-x86
@@ -10,7 +10,9 @@ VALID_BUILDS = Host Ioc
 
 CMPLR_CLASS = msvc
 
-OPT_WHOLE_PROGRAM = YES
+## ISIS STFC: disable whole program optimisation as affects binary compatibility
+## ISIS STFC: between different versions of visual studio
+OPT_WHOLE_PROGRAM = NO
 
 #-------------------------------------------------------
 

--- a/configure/os/CONFIG.win32-x86.win32-x86
+++ b/configure/os/CONFIG.win32-x86.win32-x86
@@ -11,7 +11,8 @@ VALID_BUILDS = Host Ioc
 CMPLR_CLASS = msvc
 
 ## ISIS STFC: disable whole program optimisation as affects binary compatibility
-## ISIS STFC: between different versions of visual studio
+## ISIS STFC: between different versions of visual studio. Debug and static builds have it disabled 
+## ISIS STFC: by default - this just applies it to DLL Release builds too
 ## ISIS STFC: See https://docs.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017?view=msvc-160
 
 OPT_WHOLE_PROGRAM = NO

--- a/configure/os/CONFIG.win32-x86.win32-x86
+++ b/configure/os/CONFIG.win32-x86.win32-x86
@@ -12,6 +12,8 @@ CMPLR_CLASS = msvc
 
 ## ISIS STFC: disable whole program optimisation as affects binary compatibility
 ## ISIS STFC: between different versions of visual studio
+## ISIS STFC: See https://docs.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017?view=msvc-160
+
 OPT_WHOLE_PROGRAM = NO
 
 #-------------------------------------------------------


### PR DESCRIPTION
Disable whole program optimisation by default (currently only done for static builds). This is to preserve binary compatibility between visual studio versions as per  https://docs.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017?view=msvc-160
