### PR TITLE
Use Z7 for debug symbols rather than Zi

### DIFF
--- a/configure/os/CONFIG.win32-x86.win32-x86
+++ b/configure/os/CONFIG.win32-x86.win32-x86
@@ -49,15 +49,17 @@ WARN_CFLAGS_NO  = -W1
 # -Ox maximum optimizations
 # -GL whole program optimization
 # -Oy- re-enable creation of frame pointers
-# -Zi generate program database for debugging information
-OPT_CFLAGS_YES_YES = -Ox -GL -Oy- -Zi
-OPT_CFLAGS_YES_NO = -Ox -Oy- -Zi
+# -Zi generate temporary program database for debugging information
+# -Z7 puts debugging information in object file
+OPT_CFLAGS_YES_YES = -Ox -GL -Oy- -Z7
+OPT_CFLAGS_YES_NO = -Ox -Oy- -Z7
 OPT_CFLAGS_YES = $(OPT_CFLAGS_YES_$(OPT_WHOLE_PROGRAM))
 
 #
 # -Zi generate program database for debugging information
+# -Z7 puts debugging information in object file
 # -RTCsu enable run-time error checks
-OPT_CFLAGS_NO = -Zi -RTCsu
+OPT_CFLAGS_NO = -Z7 -RTCsu
 
 # specify object file name and location
 OBJ_CFLAG = -Fo
@@ -118,14 +120,16 @@ WARN_CXXFLAGS_NO  = -W1
 # -GL whole program optimization
 # -Oy- re-enable creation of frame pointers
 # -Zi generate program database for debugging information
-OPT_CXXFLAGS_YES_YES = -Ox -GL -Oy- -Zi
-OPT_CXXFLAGS_YES_NO = -Ox -Oy- -Zi
+# -Z7 puts debugging information in object file
+OPT_CXXFLAGS_YES_YES = -Ox -GL -Oy- -Z7
+OPT_CXXFLAGS_YES_NO = -Ox -Oy- -Z7
 OPT_CXXFLAGS_YES = $(OPT_CXXFLAGS_YES_$(OPT_WHOLE_PROGRAM))
 
 #
 # -Zi generate program database for debugging information
+# -Z7 puts debugging information in object file
 # -RTCsu enable run-time error checks
-OPT_CXXFLAGS_NO = -RTCsu -Zi
+OPT_CXXFLAGS_NO = -RTCsu -Z7
 
 # specify object file name and location
 OBJ_CXXFLAG = -Fo
@@ -152,19 +156,6 @@ STATIC_LDFLAGS_EXTRA_NO=/NODEFAULTLIB:LIBCMT.LIB /NODEFAULTLIB:LIBCMTD.LIB /NODE
 RANLIB=
 
 #
-# option needed for parallel builds with Visual Studio 2013 onward
-# VS2012 and above have VisualStudioVersion, so just need to exclude 2012 (11.0)
-# -FS Force Synchronous PDB Writes
-#
-ifneq ($(VisualStudioVersion),)
-ifneq ($(VisualStudioVersion),11.0)
-  OPT_CXXFLAGS_NO += -FS
-  OPT_CFLAGS_NO += -FS
-endif
-endif
-
-
-#
 # add -profile here to run the ms profiler
 # -LTCG whole program optimization
 # -incremental:no full linking
@@ -186,13 +177,6 @@ SHRLIB_CFLAGS=
 
 OS_CLASS=WIN32
 POSIX=NO
-
-ifneq ($(VisualStudioVersion),)
-OPT_CXXFLAGS_NO += -FS
-OPT_CXXFLAGS_YES += -FS
-OPT_CFLAGS_NO += -FS
-OPT_CFLAGS_YES += -FS
-endif
 
 #	ifdef WIN32   looks better that  ifeq ($(OS_CLASS),WIN32)  ??
 WIN32=1


### PR DESCRIPTION
Use `-Z7` rather than `-Zi` to generate debug symbols, this is to try and avoid below build failures that still seem to occur even when `/FS` is used 

```
17:05:03  cl -EHsc -GR               -nologo -FC -D__STDC__=0 -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE   -Ox -Oy- -Zi -FS   -W3 -w44355 -w44344 -w44251    -D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING    -MD -DEPICS_BUILD_DLL -DEPICS_CALL_DLL -TP  -I. -I../O.Common -I. -I. -I.. -I../../../include/compiler/msvc -I../../../include/os/WIN32 -I../../../include   -IC:/Instrument/Apps/EPICS/support/ipac/master/include   -IC:/Instrument/Apps/EPICS/support/seq/master/include   -IC:/Instrument/Apps/EPICS/support/oncrpc/master/include    -IC:/Instrument/Apps/EPICS/base/master/include/compiler/msvc -IC:/Instrument/Apps/EPICS/base/master/include/os/WIN32 -IC:/Instrument/Apps/EPICS/base/master/include                             -c test_registerRecordDeviceDriver.cpp
17:05:03  test_registerRecordDeviceDriver.cpp
17:05:03  c:\instrument\apps\epics\support\asyn\master\testapp\src\o.windows-x64\test_registerrecorddevicedriver.cpp: fatal error C1041: cannot open program database 'C:\Instrument\Apps\EPICS\support\asyn\master\testApp\src\O.windows-x64\vc140.pdb'; if multiple CL.EXE write to the same .PDB file, please use /FS
17:05:03  make[6]: *** [C:/Instrument/Apps/EPICS/base/master/configure/RULES_BUILD:250: test_registerRecordDeviceDriver.obj] Error 2
```