### PR TITLE
Fix uninstall issue with removing convertRelease.pl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,6 @@ include $(TOP)/configure/RULES_TOP
 CONVERTRELEASE_PATH = $(INSTALL_LOCATION_BIN)/$(EPICS_HOST_ARCH)/convertRelease.pl
 CONVERTRELEASE_WINPATH = $(subst /,\,$(CONVERTRELEASE_PATH))
 preuninstall::
-ifneq ($(findstring windows,$(BUILD_ARCHS)),)
+ifneq ($(findstring windows,$(EPICS_HOST_ARCH)),)
 	if exist $(CONVERTRELEASE_WINPATH) del /f $(CONVERTRELEASE_WINPATH)
 endif

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,14 @@ DIRS += modules
 modules_DEPEND_DIRS = src
 
 include $(TOP)/configure/RULES_TOP
+
+# we need to delete convertRelease.pl first separately as on windows
+# going via the RMDIR gives a file in use error
+# we need to create out own CONVERTRELEASE_PATH as existing CONVERTRELEASE
+# may not point at install location
+CONVERTRELEASE_PATH = $(INSTALL_LOCATION_BIN)/$(EPICS_HOST_ARCH)/convertRelease.pl
+CONVERTRELEASE_WINPATH = $(subst /,\,$(CONVERTRELEASE_PATH))
+preuninstall::
+ifneq ($(findstring windows,$(BUILD_ARCHS)),)
+	if exist $(CONVERTRELEASE_WINPATH) del /f $(CONVERTRELEASE_WINPATH)
+endif

--- a/configure/RULES_TOP
+++ b/configure/RULES_TOP
@@ -43,12 +43,14 @@ ifndef DISABLE_TOP_RULES
   uninstallDirs:
 	$(RMDIR) $(UNINSTALL_DIRS)
 
+  preuninstall::
+
   # Remove the bin and lib directories if they have no sub-directories
   #
   EMPTY_INSTALL_DIRS = \
       $(if $(wildcard $(INSTALL_LOCATION_BIN)/*),,$(INSTALL_LOCATION_BIN)) \
       $(if $(wildcard $(INSTALL_LOCATION_LIB)/*),,$(INSTALL_LOCATION_LIB))
-  uninstall: archuninstall uninstallDirs
+  uninstall: preuninstall archuninstall uninstallDirs
 	$(RMDIR) $(EMPTY_INSTALL_DIRS)
 
   archuninstall: $(addprefix uninstall$(DIVIDER),$(BUILD_ARCHS))

--- a/src/template/base/top/.gitignore
+++ b/src/template/base/top/.gitignore
@@ -7,13 +7,17 @@
 /include/
 /lib/
 /templates/
+/data/
 
 # Local configuration files
 /configure/*.local
 
 # iocBoot generated files
 /iocBoot/*ioc*/cdCommands
-/iocBoot/*ioc*/dllPath.bat
+/iocBoot/*ioc*/dllPath*.bat
+/iocBoot/*ioc*/dllCopy.bat
+/iocBoot/*ioc*/runIOC.bat
+/iocBoot/*ioc*/runIOC.sh
 /iocBoot/*ioc*/envPaths
 /iocBoot/*ioc*/relPaths.sh
 


### PR DESCRIPTION
During a `make clean uninstall` of epics base (and elsewhere after epics base was cleaned) you would see errors like
```
Can't locate EPICS/Path.pm in @INC (you may need to install the EPICS::Path module) (@INC contains: C:/Instrument/Apps/E
PICS/base/master/bin/windows-x64/../../lib/perl C:/Instrument/Apps/EPICS/base/master/bin/windows-x64 c:/Strawberry/perl/
site/lib c:/Strawberry/perl/vendor/lib c:/Strawberry/perl/lib) at C:/Instrument/Apps/EPICS/base/master/bin/windows-x64/c
onvertRelease.pl line 25.
BEGIN failed--compilation aborted at C:/Instrument/Apps/EPICS/base/master/bin/windows-x64/convertRelease.pl line 25.
```
this is because the clean of epics base tries but fails to delete the installed `convertRelease.pl` from bin (file is said to be in use), but does delete all the modules it would load, hence it continues to call it and it fails. What should happen is the bin installed version is removed, then it automatically falls back to the one in src that works.

This PR makes it remove the file - not sure why it is considered in use, but using an external del rather than perl seems to help  

## To test

type `make clean uninstall` a couple of times in your `base/master` - it should give above error. Then swap to branch and error should go away. 

